### PR TITLE
[#5] Adding color picker to context pad

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bpmn-js": "^14.2.0",
     "bpmn-js-guideline-validator": "^0.1.0",
     "bpmn-js-properties-panel": "^1.26.0",
+    "bpmn-js-color-picker": "^0.7.1",
     "bpmn-moddle": "^0.3.0",
     "camunda-bpmn-js-behaviors": "^1.0.0",
     "cors": "^2.8.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import BpmnModeler from 'bpmn-js/lib/Modeler';
+import BpmnColorPickerModule from 'bpmn-js-color-picker';
 import {
   BpmnPropertiesPanelModule,
   BpmnPropertiesProviderModule
@@ -24,6 +25,7 @@ var bpmnModeler = new BpmnModeler({
     parent: '#js-properties-panel'
   },
   additionalModules: [
+    BpmnColorPickerModule,
     BpmnPropertiesPanelModule,
     BpmnPropertiesProviderModule,
     magicPropertiesProviderModule,


### PR DESCRIPTION
For more info see https://github.com/bpmn-io/bpmn-js-color-picker

To test, first run `npm install`.